### PR TITLE
Py3 audio issue

### DIFF
--- a/src/vi/soundmanager.py
+++ b/src/vi/soundmanager.py
@@ -65,7 +65,6 @@ class SoundManager(six.with_metaclass(Singleton)):
             self._soundThread.start()
 
     def platformSupportsAudio(self):
-        print("%r, %r" % (self.platformSupportsSpeech(), gPygletAvailable))
         return self.platformSupportsSpeech() or gPygletAvailable
 
     def platformSupportsSpeech(self):
@@ -86,7 +85,7 @@ class SoundManager(six.with_metaclass(Singleton)):
     def playSound(self, name="alarm", message="", abbreviatedMessage=""):
         """ Schedules the work, which is picked up by SoundThread.run()
         """
-        if self.soundActive:
+        if self.soundActive and self.soundAvailable:
             if self.useSpokenNotifications:
                 audioFile = None
             else:
@@ -94,8 +93,9 @@ class SoundManager(six.with_metaclass(Singleton)):
             self._soundThread.queue.put((audioFile, message, abbreviatedMessage))
 
     def quit(self):
-        self._soundThread.queue.task_done()
-        self._soundThread.quit()
+        if self.soundAvailable:
+            self._soundThread.queue.task_done()
+            self._soundThread.quit()
 
     #
     #  Inner class handle audio playback without blocking the UI

--- a/src/vi/soundmanager.py
+++ b/src/vi/soundmanager.py
@@ -23,6 +23,7 @@ import sys
 import re
 import requests
 import time
+import six
 
 from collections import namedtuple
 from PyQt4.QtCore import QThread
@@ -43,9 +44,7 @@ except ImportError:
     gPygletAvailable = False
 
 
-class SoundManager:
-    __metaclass__ = Singleton
-
+class SoundManager(six.with_metaclass(Singleton)):
     SOUNDS = {"alarm": "178032__zimbot__redalert-klaxon-sttos-recreated.wav",
               "kos": "178031__zimbot__transporterstartbeep0-sttos-recreated.wav",
               "request": "178028__zimbot__bosun-whistle-sttos-recreated.wav"}
@@ -59,10 +58,15 @@ class SoundManager:
 
     def __init__(self):
         self._soundThread = self.SoundThread()
-        self._soundThread.start()
-        self.soundAvailable = True
+        self.soundAvailable = self.platformSupportsAudio()
         if not self.platformSupportsSpeech():
             self.useSpokenNotifications = False
+        if self.soundAvailable:
+            self._soundThread.start()
+
+    def platformSupportsAudio(self):
+        print("%r, %r" % (self.platformSupportsSpeech(), gPygletAvailable))
+        return self.platformSupportsSpeech() or gPygletAvailable
 
     def platformSupportsSpeech(self):
         if self._soundThread.isDarwin:


### PR DESCRIPTION
Python3 uses a different approach of defining metaclasses, as such,
there was something going off that was causing issues.

The Singleton metaclass assumes that SoundManager is only instanced
once, and as such, does it's thread spawning and audio initialisation
inside it's __init__... now seeing python3 doesn't listen to the
__metaclasss___ property on a class, this was actually done multiple
times; causing the audio subsystem to attempt to initialize multiple
times, causing a segfault in the underlying libraries.

For added cleanliness, I created a separate platformSupportsAudio that does the check if audio is available (either a darwin system, or pyglet is there), this should prevent an unneeded thread from aimlessly polling and doing nothing....