### PR TITLE
Qt4 to Qt5 migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .idea/workspace.xml
 .vs/*
 *.pyproj
+*.e4p

--- a/src/vi/PanningWebView.py
+++ b/src/vi/PanningWebView.py
@@ -1,10 +1,10 @@
 
-from PyQt4.QtWebKit import QWebView
-from PyQt4.QtGui import *
-from PyQt4 import QtCore
-from PyQt4.QtCore import QPoint
-from PyQt4.QtCore import QString
-from PyQt4.QtCore import QEvent
+from PyQt5.QtWebKitWidgets import QWebView
+from PyQt5.QtGui import *
+from PyQt5.QtWidgets import *
+from PyQt5 import QtCore
+from PyQt5.QtCore import QPoint
+from PyQt5.QtCore import QEvent
 
 class PanningWebView(QWebView):
 
@@ -33,12 +33,12 @@ class PanningWebView(QWebView):
 
                 self.position = mouseEvent.pos()
                 frame = self.page().mainFrame()
-                xTuple = frame.evaluateJavaScript("window.scrollX").toInt()
-                yTuple = frame.evaluateJavaScript("window.scrollY").toInt()
-                self.offset = QPoint(xTuple[0], yTuple[0])
+                xTuple = (frame.evaluateJavaScript("window.scrollX"))
+                yTuple = (frame.evaluateJavaScript("window.scrollY"))
+                self.offset = QPoint(xTuple, yTuple)
                 return
 
-        return QWebView.mousePressEvent(mouseEvent)
+        return QWebView.mousePressEvent(self, mouseEvent)
 
 
     def mouseReleaseEvent(self, mouseEvent):
@@ -83,7 +83,7 @@ class PanningWebView(QWebView):
             delta = mouseEvent.pos() - self.position
             p = self.offset - delta
             frame = self.page().mainFrame()
-            frame.evaluateJavaScript(QString("window.scrollTo(%1, %2);").arg(p.x()).arg(p.y()));
+            frame.evaluateJavaScript('window.scrollTo({}, {});'.format(p.x(), p.y() ) )
             return
 
         if self.pressed:
@@ -92,3 +92,4 @@ class PanningWebView(QWebView):
             return
 
         return QWebView.mouseMoveEvent(self, mouseEvent)
+

--- a/src/vi/amazon_s3.py
+++ b/src/vi/amazon_s3.py
@@ -21,8 +21,8 @@ import json
 import requests
 import logging
 
-from PyQt4 import Qt
-from PyQt4.QtCore import QThread
+from PyQt5 import Qt
+from PyQt5.QtCore import pyqtSignal, QThread
 from vi import version
 from vi.cache.cache import Cache
 from distutils.version import LooseVersion, StrictVersion
@@ -62,6 +62,8 @@ def getNewestVersion():
 
 
 class NotifyNewVersionThread(QThread):
+    newVersion = pyqtSignal(str)
+    
     def __init__(self):
         QThread.__init__(self)
         self.alerted = False
@@ -72,7 +74,7 @@ class NotifyNewVersionThread(QThread):
                 # Is there a newer version available?
                 newestVersion = getNewestVersion()
                 if newestVersion and StrictVersion(newestVersion) > StrictVersion(version.VERSION):
-                    self.emit(Qt.SIGNAL("newer_version"), newestVersion)
+                    self.newVersion.emit(newestVersion)
                     self.alerted = True
             except Exception as e:
                 logging.error("Failed NotifyNewVersionThread: %s", e)

--- a/src/vi/chatparser/chatparser.py
+++ b/src/vi/chatparser/chatparser.py
@@ -24,7 +24,7 @@ import six
 if six.PY2:
     from io import open
 
-from PyQt4 import QtGui
+from PyQt5 import QtGui
 from bs4 import BeautifulSoup
 from vi import states
 

--- a/src/vi/chatparser/chatparser.py
+++ b/src/vi/chatparser/chatparser.py
@@ -184,12 +184,14 @@ class ChatParser(object):
         if username in ("EVE-System", "EVE System"):
             if ":" in text:
                 system = text.split(":")[1].strip().replace("*", "").upper()
+                status = states.LOCATION
             else:
-                system = "?"
+                # We could not determine if the message was system-change related
+                status = states.IGNORE
             if timestamp > self.locations[charname]["timestamp"]:
                 self.locations[charname]["system"] = system
                 self.locations[charname]["timestamp"] = timestamp
-                message = Message("", "", timestamp, charname, [system, ], "", status=states.LOCATION)
+                message = Message("", "", timestamp, charname, [system, ], "", status)
         return message
 
     def fileModified(self, path):

--- a/src/vi/chatparser/chatparser.py
+++ b/src/vi/chatparser/chatparser.py
@@ -187,11 +187,12 @@ class ChatParser(object):
                 status = states.LOCATION
             else:
                 # We could not determine if the message was system-change related
+                system = "?"
                 status = states.IGNORE
             if timestamp > self.locations[charname]["timestamp"]:
                 self.locations[charname]["system"] = system
                 self.locations[charname]["timestamp"] = timestamp
-                message = Message("", "", timestamp, charname, [system, ], "", status)
+                message = Message("", "", timestamp, charname, [system, ], "", "", status)
         return message
 
     def fileModified(self, path):

--- a/src/vi/filewatcher.py
+++ b/src/vi/filewatcher.py
@@ -22,8 +22,8 @@ import stat
 import time
 import logging
 
-from PyQt4 import QtCore
-from PyQt4.QtCore import SIGNAL
+from PyQt5 import QtCore
+from PyQt5.QtCore import  pyqtSignal
 
 """
 There is a problem with the QFIleWatcher on Windows and the log
@@ -40,6 +40,8 @@ if a new file was created. We watch only the newest (last 24h), not all!
 DEFAULT_MAX_AGE = 60 * 60 * 24
 
 class FileWatcher(QtCore.QThread):
+    fileChanged = pyqtSignal(str)
+    
     def __init__(self, path, maxAge=DEFAULT_MAX_AGE):
         QtCore.QThread.__init__(self)
         self.path = path
@@ -64,7 +66,7 @@ class FileWatcher(QtCore.QThread):
                 if not stat.S_ISREG(pathStat.st_mode):
                     continue
                 if modified < pathStat.st_size:
-                    self.emit(SIGNAL("file_change"), path)
+                    self.fileChanged.emit(path)
                 self.files[path] = pathStat.st_size
 
     def updateWatchedFiles(self):

--- a/src/vi/soundmanager.py
+++ b/src/vi/soundmanager.py
@@ -26,7 +26,7 @@ import time
 import six
 
 from collections import namedtuple
-from PyQt4.QtCore import QThread
+from PyQt5.QtCore import QThread
 from .resources import resourcePath
 from six.moves import queue
 

--- a/src/vi/threads.py
+++ b/src/vi/threads.py
@@ -21,9 +21,9 @@ import time
 import logging
 
 from six.moves import queue
-from PyQt4 import QtCore
-from PyQt4.QtCore import QThread
-from PyQt4.QtCore import SIGNAL
+from PyQt5 import QtCore
+from PyQt5.QtCore import QThread
+from PyQt5.QtCore import pyqtSignal
 from vi import evegate
 from vi import koschecker
 from vi.cache.cache import Cache
@@ -32,7 +32,8 @@ from vi.resources import resourcePath
 STATISTICS_UPDATE_INTERVAL_MSECS = 1 * 60 * 1000
 
 class AvatarFindThread(QThread):
-
+    avatarUpdate = pyqtSignal(object,  object)
+    
     def __init__(self):
         QThread.__init__(self)
         self.queue = queue.Queue()
@@ -78,13 +79,14 @@ class AvatarFindThread(QThread):
                         cache.putAvatar(charname, avatar)
                 if avatar:
                     logging.debug("AvatarFindThread emit avatar_update for %s" % charname)
-                    self.emit(SIGNAL("avatar_update"), chatEntry, avatar)
+                    self.avatarUpdate.emit(chatEntry, avatar)
             except Exception as e:
                 logging.error("Error in AvatarFindThread : %s", e)
 
 
 class KOSCheckerThread(QThread):
-
+    showKos = pyqtSignal(str,  str,  str,  bool)
+ 
     def __init__(self):
         QThread.__init__(self)
         self.queue = queue.Queue()
@@ -130,10 +132,11 @@ class KOSCheckerThread(QThread):
 
             logging.info("KOSCheckerThread emitting kos_result for: state = {0}, text = {1}, requestType = {2}, hasKos = {3}".format(
                     "ok", text, requestType, hasKos))
-            self.emit(SIGNAL("kos_result"), "ok", text, requestType, hasKos)
+            self.showKos.emit("ok", text, requestType, hasKos)
 
 
 class MapStatisticsThread(QThread):
+    updateMap = pyqtSignal(str)
 
     def __init__(self):
         QThread.__init__(self)
@@ -147,7 +150,7 @@ class MapStatisticsThread(QThread):
 
     def run(self):
         self.refreshTimer = QtCore.QTimer()
-        self.connect(self.refreshTimer, QtCore.SIGNAL("timeout()"), self.requestStatistics)
+        self.refreshTimer.timeout.connect(self.requestStatistics)
         while True:
             # Block waiting for requestStatistics() to enqueue a token
             self.queue.get()
@@ -162,5 +165,5 @@ class MapStatisticsThread(QThread):
                 requestData = {"result": "error", "text": unicode(e)}
             self.lastStatisticsUpdate = time.time()
             self.refreshTimer.start(self.pollRate)
-            self.emit(SIGNAL("statistic_data_update"), requestData)
+            self.updateMap.emit(requestData)
             logging.debug("MapStatisticsThread emitted statistic_data_update")

--- a/src/vi/ui/systemtray.py
+++ b/src/vi/ui/systemtray.py
@@ -20,51 +20,52 @@
 import time
 
 from six.moves import range
-from PyQt4 import QtGui, QtCore, Qt
+from PyQt5 import QtGui, QtCore, Qt, QtWidgets
+from PyQt5.QtCore import pyqtSignal
 
 from vi.resources import resourcePath
 from vi import states
 from vi.soundmanager import SoundManager
 
 
-class TrayContextMenu(QtGui.QMenu):
+class TrayContextMenu(QtWidgets.QMenu):
     instances = set()
 
     def __init__(self, trayIcon):
         """ trayIcon = the object with the methods to call
         """
-        QtGui.QMenu.__init__(self)
+        QtWidgets.QMenu.__init__(self)
         TrayContextMenu.instances.add(self)
         self.trayIcon = trayIcon
         self._buildMenu()
 
     def _buildMenu(self):
-        self.framelessCheck = QtGui.QAction("Frameless Window", self, checkable=True)
-        self.connect(self.framelessCheck, QtCore.SIGNAL("triggered()"), self.trayIcon.changeFrameless)
+        self.framelessCheck = QtWidgets.QAction("Frameless Window", self, checkable=True)
+        self.framelessCheck.triggered.connect(self.trayIcon.changeFrameless)
         self.addAction(self.framelessCheck)
         self.addSeparator()
-        self.requestCheck = QtGui.QAction("Show status request notifications", self, checkable=True)
+        self.requestCheck = QtWidgets.QAction("Show status request notifications", self, checkable=True)
         self.requestCheck.setChecked(True)
         self.addAction(self.requestCheck)
-        self.connect(self.requestCheck, QtCore.SIGNAL("triggered()"), self.trayIcon.switchRequest)
-        self.alarmCheck = QtGui.QAction("Show alarm notifications", self, checkable=True)
+        self.requestCheck.triggered.connect(self.trayIcon.switchRequest)
+        self.alarmCheck = QtWidgets.QAction("Show alarm notifications", self, checkable=True)
         self.alarmCheck.setChecked(True)
-        self.connect(self.alarmCheck, QtCore.SIGNAL("triggered()"), self.trayIcon.switchAlarm)
+        self.alarmCheck.triggered.connect(self.trayIcon.switchAlarm)
         self.addAction(self.alarmCheck)
         distanceMenu = self.addMenu("Alarm Distance")
-        self.distanceGroup = QtGui.QActionGroup(self)
+        self.distanceGroup = QtWidgets.QActionGroup(self)
         for i in range(0, 6):
-            action = QtGui.QAction("{0} Jumps".format(i), None, checkable=True)
+            action = QtWidgets.QAction("{0} Jumps".format(i), None, checkable=True)
             if i == 0:
                 action.setChecked(True)
             action.alarmDistance = i
-            self.connect(action, QtCore.SIGNAL("triggered()"), self.changeAlarmDistance)
+            self.distanceGroup.triggered.connect(self.changeAlarmDistance)
             self.distanceGroup.addAction(action)
             distanceMenu.addAction(action)
         self.addMenu(distanceMenu)
         self.addSeparator()
-        self.quitAction = QtGui.QAction("Quit", self)
-        self.connect(self.quitAction, Qt.SIGNAL("triggered()"), self.trayIcon.quit)
+        self.quitAction = QtWidgets.QAction("Quit", self)
+        self.quitAction.triggered.connect(self.trayIcon.quit)
         self.addAction(self.quitAction)
 
     def changeAlarmDistance(self):
@@ -74,13 +75,17 @@ class TrayContextMenu(QtGui.QMenu):
                 self.trayIcon.changeAlarmDistance()
 
 
-class TrayIcon(QtGui.QSystemTrayIcon):
+class TrayIcon(QtWidgets.QSystemTrayIcon):
     # Min seconds between two notifications
     MIN_WAIT_NOTIFICATION = 15
+    
+    alarmDistanceChange = pyqtSignal(int)
+    changeFramelessSignal = pyqtSignal()
+    quitSignal = pyqtSignal()
 
     def __init__(self, app):
         self.icon = QtGui.QIcon(resourcePath("vi/ui/res/logo_small.png"))
-        QtGui.QSystemTrayIcon.__init__(self, self.icon, app)
+        QtWidgets.QSystemTrayIcon.__init__(self, self.icon, app)
         self.setToolTip("Your Vintel-Information-Service! :)")
         self.lastNotifications = {}
         self.setContextMenu(TrayContextMenu(self))
@@ -90,17 +95,17 @@ class TrayIcon(QtGui.QSystemTrayIcon):
 
     def changeAlarmDistance(self):
         distance = self.alarmDistance
-        self.emit(Qt.SIGNAL("alarm_distance"), distance)
+        self.alarmDistanceChange.emit(distance)
 
     def changeFrameless(self):
-        self.emit(Qt.SIGNAL("change_frameless"))
+        self.changeFramelessSignal.emit()
 
     @property
     def distanceGroup(self):
         return self.contextMenu().distanceGroup
 
     def quit(self):
-        self.emit(Qt.SIGNAL("quit"))
+        self.quitSignal.emit()
 
     def switchAlarm(self):
         newValue = not self.showAlarm

--- a/src/vi/ui/viui.py
+++ b/src/vi/ui/viui.py
@@ -898,12 +898,12 @@ class SystemChat(QtWidgets.QDialog):
             scrollToBottom = True
         entry = ChatEntryWidget(message)
         entry.avatarLabel.setPixmap(avatarPixmap)
-        listWidgetItem = QtGui.QListWidgetItem(self.chat)
+        listWidgetItem = QtWidgets.QListWidgetItem(self.chat)
         listWidgetItem.setSizeHint(entry.sizeHint())
         self.chat.addItem(listWidgetItem)
         self.chat.setItemWidget(listWidgetItem, entry)
         self.chatEntries.append(entry)
-        self.markSystem.connect(self.parent.markSystemOnMap)
+        entry.markSystem.connect(self.parent.markSystemOnMap)
         if scrollToBottom:
             self.chat.scrollToBottom()
 

--- a/src/vi/ui/viui.py
+++ b/src/vi/ui/viui.py
@@ -27,11 +27,13 @@ import webbrowser
 import vi.version
 
 import logging
-from PyQt4.QtGui import *
-from PyQt4 import Qt, QtGui, uic, QtCore
-from PyQt4.QtCore import QPoint
-from PyQt4.QtGui import QImage, QPixmap, QMessageBox
-from PyQt4.QtWebKit import QWebPage
+from PyQt5.QtGui import *
+from PyQt5.QtWidgets import *
+from PyQt5 import Qt, QtGui, uic, QtCore, QtWidgets
+from PyQt5.QtCore import pyqtSignal, QPoint
+from PyQt5.QtGui import QImage, QPixmap
+from PyQt5.QtWidgets import QMessageBox
+from PyQt5.QtWebKitWidgets import QWebPage
 from vi import amazon_s3, evegate
 from vi import chatparser, dotlan, filewatcher
 from vi import states
@@ -47,12 +49,15 @@ MAP_UPDATE_INTERVAL_MSECS = 4 * 1000
 CLIPBOARD_CHECK_INTERVAL_MSECS = 4 * 1000
 
 
-class MainWindow(QtGui.QMainWindow):
+class MainWindow(QtWidgets.QMainWindow):
 
+    # Window Signals
+    chatMessageAdded = pyqtSignal(object)
+    avatarLoaded = pyqtSignal(str, object)
 
     def __init__(self, pathToLogs, trayIcon, backGroundColor):
 
-        QtGui.QMainWindow.__init__(self)
+        QtWidgets.QMainWindow.__init__(self)
         self.cache = Cache()
 
         if backGroundColor:
@@ -65,12 +70,12 @@ class MainWindow(QtGui.QMainWindow):
 
         self.pathToLogs = pathToLogs
         self.mapTimer = QtCore.QTimer(self)
-        self.connect(self.mapTimer, QtCore.SIGNAL("timeout()"), self.updateMapView)
+        self.mapTimer.timeout.connect(self.updateMapView)
         self.clipboardTimer = QtCore.QTimer(self)
         self.oldClipboardContent = ""
         self.trayIcon = trayIcon
         self.trayIcon.activated.connect(self.systemTrayActivated)
-        self.clipboard = QtGui.QApplication.clipboard()
+        self.clipboard = QtWidgets.QApplication.clipboard()
         self.clipboard.clear(mode=self.clipboard.Clipboard)
         self.alarmDistance = 0
         self.lastStatisticsUpdate = 0
@@ -87,7 +92,7 @@ class MainWindow(QtGui.QMainWindow):
         else:
             self.knownPlayerNames = set()
             diagText = "Vintel scans EVE system logs and remembers your characters as they change systems.\n\nSome features (clipboard KOS checking, alarms, etc.) may not work until your character(s) have been registered. Change systems, with each character you want to monitor, while Vintel is running to remedy this."
-            QtGui.QMessageBox.warning(None, "Known Characters not Found", diagText, "Ok")
+            QtWidgets.QMessageBox.warning(None, "Known Characters not Found", diagText, QMessageBox.Ok)
 
         # Set up user's intel rooms
         roomnames = self.cache.getFromCache("room_names")
@@ -105,13 +110,13 @@ class MainWindow(QtGui.QMainWindow):
             self.changeSound()
 
         # Set up Transparency menu - fill in opacity values and make connections
-        self.opacityGroup = QtGui.QActionGroup(self.menu)
+        self.opacityGroup = QtWidgets.QActionGroup(self.menu)
         for i in (100, 80, 60, 40, 20):
-            action = QtGui.QAction("Opacity {0}%".format(i), None, checkable=True)
+            action = QtWidgets.QAction("Opacity {0}%".format(i), None, checkable=True)
             if i == 100:
                 action.setChecked(True)
             action.opacity = i / 100.0
-            self.connect(action, QtCore.SIGNAL("triggered()"), self.changeOpacity)
+            self.opacityGroup.triggered.connect(self.changeOpacity)
             self.opacityGroup.addAction(action)
             self.menuTransparency.addAction(action)
 
@@ -151,59 +156,59 @@ class MainWindow(QtGui.QMainWindow):
 
     def wireUpUIConnections(self):
         # Wire up general UI connections
-        self.connect(self.clipboard, Qt.SIGNAL("changed(QClipboard::Mode)"), self.clipboardChanged)
-        self.connect(self.autoScanIntelAction, Qt.SIGNAL("triggered()"), self.changeAutoScanIntel)
-        self.connect(self.kosClipboardActiveAction, Qt.SIGNAL("triggered()"), self.changeKosCheckClipboard)
-        self.connect(self.zoomInButton, Qt.SIGNAL("clicked()"), self.zoomMapIn)
-        self.connect(self.zoomOutButton, Qt.SIGNAL("clicked()"), self.zoomMapOut)
-        self.connect(self.statisticsButton, Qt.SIGNAL("clicked()"), self.changeStatisticsVisibility)
-        self.connect(self.jumpbridgesButton, Qt.SIGNAL("clicked()"), self.changeJumpbridgesVisibility)
-        self.connect(self.chatLargeButton, Qt.SIGNAL("clicked()"), self.chatLarger)
-        self.connect(self.chatSmallButton, Qt.SIGNAL("clicked()"), self.chatSmaller)
-        self.connect(self.infoAction, Qt.SIGNAL("triggered()"), self.showInfo)
-        self.connect(self.showChatAvatarsAction, Qt.SIGNAL("triggered()"), self.changeShowAvatars)
-        self.connect(self.alwaysOnTopAction, Qt.SIGNAL("triggered()"), self.changeAlwaysOnTop)
-        self.connect(self.chooseChatRoomsAction, Qt.SIGNAL("triggered()"), self.showChatroomChooser)
-        self.connect(self.catchRegionAction, Qt.SIGNAL("triggered()"), lambda : self.handleRegionMenuItemSelected(self.catchRegionAction))
-        self.connect(self.providenceRegionAction, Qt.SIGNAL("triggered()"), lambda : self.handleRegionMenuItemSelected(self.providenceRegionAction))
-        self.connect(self.queriousRegionAction, Qt.SIGNAL("triggered()"), lambda : self.handleRegionMenuItemSelected(self.queriousRegionAction))
-        self.connect(self.providenceCatchRegionAction, Qt.SIGNAL("triggered()"), lambda : self.handleRegionMenuItemSelected(self.providenceCatchRegionAction))
-        self.connect(self.providenceCatchCompactRegionAction, Qt.SIGNAL("triggered()"), lambda : self.handleRegionMenuItemSelected(self.providenceCatchCompactRegionAction))
-        self.connect(self.chooseRegionAction, Qt.SIGNAL("triggered()"), self.showRegionChooser)
-        self.connect(self.showChatAction, Qt.SIGNAL("triggered()"), self.changeChatVisibility)
-        self.connect(self.soundSetupAction, Qt.SIGNAL("triggered()"), self.showSoundSetup)
-        self.connect(self.activateSoundAction, Qt.SIGNAL("triggered()"), self.changeSound)
-        self.connect(self.useSpokenNotificationsAction, Qt.SIGNAL("triggered()"), self.changeUseSpokenNotifications)
-        self.connect(self.trayIcon, Qt.SIGNAL("alarm_distance"), self.changeAlarmDistance)
-        self.connect(self.framelessWindowAction, Qt.SIGNAL("triggered()"), self.changeFrameless)
-        self.connect(self.trayIcon, Qt.SIGNAL("change_frameless"), self.changeFrameless)
-        self.connect(self.frameButton, Qt.SIGNAL("clicked()"), self.changeFrameless)
-        self.connect(self.quitAction, Qt.SIGNAL("triggered()"), self.close)
-        self.connect(self.trayIcon, Qt.SIGNAL("quit"), self.close)
-        self.connect(self.jumpbridgeDataAction, Qt.SIGNAL("triggered()"), self.showJumbridgeChooser)
+        self.clipboard.dataChanged.connect(self.clipboardChanged)
+        self.autoScanIntelAction.triggered.connect(self.changeAutoScanIntel)
+        self.kosClipboardActiveAction.triggered.connect(self.changeKosCheckClipboard)
+        self.zoomInButton.clicked.connect(self.zoomMapIn)
+        self.zoomOutButton.clicked.connect(self.zoomMapOut)
+        self.statisticsButton.clicked.connect(self.changeStatisticsVisibility)
+        self.jumpbridgesButton.clicked.connect(self.changeJumpbridgesVisibility)
+        self.chatLargeButton.clicked.connect(self.chatLarger)
+        self.chatSmallButton.clicked.connect(self.chatSmaller)
+        self.infoAction.triggered.connect(self.showInfo)
+        self.showChatAvatarsAction.triggered.connect(self.changeShowAvatars)
+        self.alwaysOnTopAction.triggered.connect(self.changeAlwaysOnTop)
+        self.chooseChatRoomsAction.triggered.connect(self.showChatroomChooser)
+        self.catchRegionAction.triggered.connect(lambda : self.handleRegionMenuItemSelected(self.catchRegionAction))
+        self.providenceRegionAction.triggered.connect(lambda : self.handleRegionMenuItemSelected(self.providenceRegionAction))
+        self.queriousRegionAction.triggered.connect(lambda : self.handleRegionMenuItemSelected(self.queriousRegionAction))
+        self.providenceCatchRegionAction.triggered.connect(lambda : self.handleRegionMenuItemSelected(self.providenceCatchRegionAction))
+        self.providenceCatchCompactRegionAction.triggered.connect(lambda : self.handleRegionMenuItemSelected(self.providenceCatchCompactRegionAction))
+        self.chooseRegionAction.triggered.connect(self.showRegionChooser)
+        self.showChatAction.triggered.connect(self.changeChatVisibility)
+        self.soundSetupAction.triggered.connect(self.showSoundSetup)
+        self.activateSoundAction.triggered.connect(self.changeSound)
+        self.useSpokenNotificationsAction.triggered.connect(self.changeUseSpokenNotifications)
+        self.trayIcon.alarmDistanceChange.connect(self.changeAlarmDistance)
+        self.framelessWindowAction.triggered.connect(self.changeFrameless)
+        self.trayIcon.changeFramelessSignal.connect(self.changeFrameless)
+        self.frameButton.clicked.connect(self.changeFrameless)
+        self.quitAction.triggered.connect(self.close)
+        self.trayIcon.quitSignal.connect(self.close)
+        self.jumpbridgeDataAction.triggered.connect(self.showJumbridgeChooser)
         self.mapView.page().scrollRequested.connect(self.mapPositionChanged)
 
 
     def setupThreads(self):
         # Set up threads and their connections
         self.avatarFindThread = AvatarFindThread()
-        self.connect(self.avatarFindThread, QtCore.SIGNAL("avatar_update"), self.updateAvatarOnChatEntry)
+        self.avatarFindThread.avatarUpdate.connect(self.updateAvatarOnChatEntry)
         self.avatarFindThread.start()
 
         self.kosRequestThread = KOSCheckerThread()
-        self.connect(self.kosRequestThread, Qt.SIGNAL("kos_result"), self.showKosResult)
+        self.kosRequestThread.showKos.connect(self.showKosResult)
         self.kosRequestThread.start()
 
         self.filewatcherThread = filewatcher.FileWatcher(self.pathToLogs)
-        self.connect(self.filewatcherThread, QtCore.SIGNAL("file_change"), self.logFileChanged)
+        self.filewatcherThread.fileChanged.connect(self.logFileChanged)
         self.filewatcherThread.start()
 
         self.versionCheckThread = amazon_s3.NotifyNewVersionThread()
-        self.versionCheckThread.connect(self.versionCheckThread, Qt.SIGNAL("newer_version"), self.notifyNewerVersion)
+        self.versionCheckThread.newVersion.connect(self.notifyNewerVersion)
         self.versionCheckThread.start()
 
         self.statisticsThread = MapStatisticsThread()
-        self.connect(self.statisticsThread, Qt.SIGNAL("statistic_data_update"), self.updateStatisticsOnMap)
+        self.statisticsThread.updateMap.connect(self.updateStatisticsOnMap)
         self.statisticsThread.start()
         # statisticsThread is blocked until first call of requestStatistics
 
@@ -227,7 +232,7 @@ class MainWindow(QtGui.QMainWindow):
             self.dotlan = dotlan.Map(regionName, svg)
         except dotlan.DotlanException as e:
             logging.error(e)
-            QtGui.QMessageBox.critical(None, "Error getting map", six.text_type(e), "Quit")
+            QtWidgets.QMessageBox.critical(None, "Error getting map", six.text_type(e), "Quit")
             sys.exit(1)
 
         if self.dotlan.outdatedCacheError:
@@ -235,7 +240,7 @@ class MainWindow(QtGui.QMainWindow):
             diagText = "Something went wrong getting map data. Proceeding with older cached data. " \
                        "Check for a newer version and inform the maintainer.\n\nError: {0} {1}".format(type(e), six.text_type(e))
             logging.warn(diagText)
-            QtGui.QMessageBox.warning(None, "Using map from cache", diagText, "Ok")
+            QtWidgets.QMessageBox.warning(None, "Using map from cache", diagText, "Ok")
 
 
         # Load the jumpbridges
@@ -254,7 +259,7 @@ class MainWindow(QtGui.QMainWindow):
 
             self.mapView.contextMenu = TrayContextMenu(self.trayIcon)
             self.mapView.contextMenuEvent = mapContextMenuEvent
-            self.mapView.connect(self.mapView, Qt.SIGNAL("linkClicked(const QUrl&)"), self.mapLinkClicked)
+            self.mapView.linkClicked.connect(self.mapLinkClicked)
 
             # Also set up our app menus
             if not regionName:
@@ -288,14 +293,18 @@ class MainWindow(QtGui.QMainWindow):
             first initializing the content so we dont kos check from random content
         """
         self.oldClipboardContent = tuple(six.text_type(self.clipboard.text()))
-        self.connect(self.clipboardTimer, QtCore.SIGNAL("timeout()"), self.clipboardChanged)
+        self.clipboardTimer.timeout.connect(self.clipboardChanged)
         self.clipboardTimer.start(CLIPBOARD_CHECK_INTERVAL_MSECS)
 
 
     def stopClipboardTimer(self):
         if self.clipboardTimer:
-           self.disconnect(self.clipboardTimer, QtCore.SIGNAL("timeout()"), self.clipboardChanged)
-           self.clipboardTimer.stop()
+            try:
+                # When settings are loaded, this will be called before it is connected.
+                self.clipboardTimer.timeout.disconnect(self.clipboardChanged)
+            except:
+                pass
+            self.clipboardTimer.stop()
 
 
     def closeEvent(self, event):
@@ -389,9 +398,9 @@ class MainWindow(QtGui.QMainWindow):
             self.activateSoundAction.setEnabled(False)
             self.soundSetupAction.setEnabled(False)
             #self.soundButton.setEnabled(False)
-            QtGui.QMessageBox.warning(None, "Sound disabled",
+            QtWidgets.QMessageBox.warning(None, "Sound disabled",
                                       "The lib 'pyglet' which is used to play sounds cannot be found, ""so the soundsystem is disabled.\nIf you want sound, please install the 'pyglet' library. This warning will not be shown again.",
-                                      "OK")
+                                      QMessageBox.Ok)
         else:
             if newValue is None:
                 newValue = self.activateSoundAction.isChecked()
@@ -497,9 +506,9 @@ class MainWindow(QtGui.QMainWindow):
         systemName = six.text_type(url.path().split("/")[-1]).upper()
         system = self.systems[str(systemName)]
         sc = SystemChat(self, SystemChat.SYSTEM, system, self.chatEntries, self.knownPlayerNames)
-        sc.connect(self, Qt.SIGNAL("chat_message_added"), sc.addChatEntry)
-        sc.connect(self, Qt.SIGNAL("avatar_loaded"), sc.newAvatarAvailable)
-        sc.connect(sc, Qt.SIGNAL("location_set"), self.setLocation)
+        self.chatMessageAdded.connect(sc.addChatEntry)
+        self.avatarLoaded.connect(sc.newAvatarAvailable)
+        sc.setLocationSignal.connect(self.setLocation)
         sc.show()
 
 
@@ -556,14 +565,14 @@ class MainWindow(QtGui.QMainWindow):
 
     def showChatroomChooser(self):
         chooser = ChatroomsChooser(self)
-        chooser.connect(chooser, Qt.SIGNAL("rooms_changed"), self.changedRoomnames)
+        chooser.roomsChanged.connect(self.changedRoomnames)
         chooser.show()
 
 
     def showJumbridgeChooser(self):
         url = self.cache.getFromCache("jumpbridge_url")
         chooser = JumpbridgeChooser(self, url)
-        chooser.connect(chooser, Qt.SIGNAL("set_jumpbridge_url"), self.setJumpbridges)
+        chooser.setJumpBridgeUrl.connect(self.setJumpbridges)
         chooser.show()
 
 
@@ -587,7 +596,7 @@ class MainWindow(QtGui.QMainWindow):
             self.dotlan.setJumpbridges(data)
             self.cache.putIntoCache("jumpbridge_url", url, 60 * 60 * 24 * 365 * 8)
         except Exception as e:
-            QtGui.QMessageBox.warning(None, "Loading jumpbridges failed!", "Error: {0}".format(six.text_type(e)), "OK")
+            QtWidgets.QMessageBox.warning(None, "Loading jumpbridges failed!", "Error: {0}".format(six.text_type(e)), "OK")
 
 
     def handleRegionMenuItemSelected(self, menuAction=None):
@@ -599,7 +608,7 @@ class MainWindow(QtGui.QMainWindow):
         self.chooseRegionAction.setChecked(False)
         if menuAction:
             menuAction.setChecked(True)
-            regionName = six.text_type(menuAction.property("regionName").toString())
+            regionName = six.text_type(str(menuAction.property("regionName")))
             regionName = dotlan.convertRegionName(regionName)
             Cache().putIntoCache("region_name", regionName, 60 * 60 * 24 * 365)
             self.setupMap()
@@ -613,7 +622,7 @@ class MainWindow(QtGui.QMainWindow):
 
         self.chooseRegionAction.setChecked(False)
         chooser = RegionChooser(self)
-        self.connect(chooser, Qt.SIGNAL("new_region_chosen"), handleRegionChosen)
+        self.chooser.newRegionChosen.connect(handleRegionChosen)
         chooser.show()
 
 
@@ -622,14 +631,14 @@ class MainWindow(QtGui.QMainWindow):
         if (self.chatListWidget.verticalScrollBar().value() == self.chatListWidget.verticalScrollBar().maximum()):
             scrollToBottom = True
         chatEntryWidget = ChatEntryWidget(message)
-        listWidgetItem = QtGui.QListWidgetItem(self.chatListWidget)
+        listWidgetItem = QtWidgets.QListWidgetItem(self.chatListWidget)
         listWidgetItem.setSizeHint(chatEntryWidget.sizeHint())
         self.chatListWidget.addItem(listWidgetItem)
         self.chatListWidget.setItemWidget(listWidgetItem, chatEntryWidget)
         self.avatarFindThread.addChatEntry(chatEntryWidget)
         self.chatEntries.append(chatEntryWidget)
-        self.connect(chatEntryWidget, Qt.SIGNAL("mark_system"), self.markSystemOnMap)
-        self.emit(Qt.SIGNAL("chat_message_added"), chatEntryWidget)
+        chatEntryWidget.markSystem.connect(self.markSystemOnMap)
+        self.chatMessageAdded.emit(chatEntryWidget)
         self.pruneMessages()
         if scrollToBottom:
             self.chatListWidget.scrollToBottom()
@@ -684,21 +693,21 @@ class MainWindow(QtGui.QMainWindow):
 
 
     def showInfo(self):
-        infoDialog = QtGui.QDialog(self)
+        infoDialog = QtWidgets.QDialog(self)
         uic.loadUi(resourcePath("vi/ui/Info.ui"), infoDialog)
         infoDialog.versionLabel.setText(u"Version: {0}".format(vi.version.VERSION))
         infoDialog.logoLabel.setPixmap(QtGui.QPixmap(resourcePath("vi/ui/res/logo.png")))
-        infoDialog.connect(infoDialog.closeButton, Qt.SIGNAL("clicked()"), infoDialog.accept)
+        infoDialog.closeButton.clicked.connect(infoDialog.accept)
         infoDialog.show()
 
 
     def showSoundSetup(self):
-        dialog = QtGui.QDialog(self)
+        dialog = QtWidgets.QDialog(self)
         uic.loadUi(resourcePath("vi/ui/SoundSetup.ui"), dialog)
         dialog.volumeSlider.setValue(SoundManager().soundVolume)
-        dialog.connect(dialog.volumeSlider, Qt.SIGNAL("valueChanged(int)"), SoundManager().setSoundVolume)
-        dialog.connect(dialog.testSoundButton, Qt.SIGNAL("clicked()"), SoundManager().playSound)
-        dialog.connect(dialog.closeButton, Qt.SIGNAL("clicked()"), dialog.accept)
+        dialog.volumeSlider.valueChanged.connect(SoundManager().setSoundVolume)
+        dialog.testSoundButton.clicked.connect(lambda: SoundManager().playSound())
+        dialog.closeButton.clicked.connect(dialog.accept)
         dialog.show()
 
 
@@ -718,7 +727,7 @@ class MainWindow(QtGui.QMainWindow):
         if not updated:
             self.avatarFindThread.addChatEntry(chatEntry, clearCache=True)
         else:
-            self.emit(Qt.SIGNAL("avatar_loaded"), chatEntry.message.user, avatarData)
+            self.avatarLoaded.emit(chatEntry.message.user, avatarData)
 
 
     def updateStatisticsOnMap(self, data):
@@ -781,13 +790,16 @@ class MainWindow(QtGui.QMainWindow):
                 self.setMapContent(self.dotlan.svg)
 
 
-class ChatroomsChooser(QtGui.QDialog):
+class ChatroomsChooser(QtWidgets.QDialog):
+
+    roomsChanged = pyqtSignal(list);
+    
     def __init__(self, parent):
-        QtGui.QDialog.__init__(self, parent)
+        QtWidgets.QDialog.__init__(self, parent)
         uic.loadUi(resourcePath("vi/ui/ChatroomsChooser.ui"), self)
-        self.connect(self.defaultButton, Qt.SIGNAL("clicked()"), self.setDefaults)
-        self.connect(self.cancelButton, Qt.SIGNAL("clicked()"), self.accept)
-        self.connect(self.saveButton, Qt.SIGNAL("clicked()"), self.saveClicked)
+        self.defaultButton.clicked.connect(self.setDefaults)
+        self.cancelButton.clicked.connect(self.accept)
+        self.saveButton.clicked.connect(self.saveClicked)
         cache = Cache()
         roomnames = cache.getFromCache("room_names")
         if not roomnames:
@@ -799,19 +811,22 @@ class ChatroomsChooser(QtGui.QDialog):
         text = six.text_type(self.roomnamesField.toPlainText())
         rooms = [six.text_type(name.strip()) for name in text.split(",")]
         self.accept()
-        self.emit(Qt.SIGNAL("rooms_changed"), rooms)
+        self.roomsChanged.emit(rooms)
 
 
     def setDefaults(self):
         self.roomnamesField.setPlainText(u"TheCitadel,North Provi Intel,North Catch Intel,North Querious Intel")
 
 
-class RegionChooser(QtGui.QDialog):
+class RegionChooser(QtWidgets.QDialog):
+    
+    newRegionChosen = pyqtSignal()
+    
     def __init__(self, parent):
-        QtGui.QDialog.__init__(self, parent)
+        QtWidgets.QDialog.__init__(self, parent)
         uic.loadUi(resourcePath("vi/ui/RegionChooser.ui"), self)
-        self.connect(self.cancelButton, Qt.SIGNAL("clicked()"), self.accept)
-        self.connect(self.saveButton, Qt.SIGNAL("clicked()"), self.saveClicked)
+        self.cancelButton.clicked.connect(self.accept)
+        self.saveButton.clicked.connect(self.saveClicked)
         cache = Cache()
         regionName = cache.getFromCache("region_name")
         if not regionName:
@@ -847,14 +862,16 @@ class RegionChooser(QtGui.QDialog):
         if correct:
             Cache().putIntoCache("region_name", text, 60 * 60 * 24 * 365)
             self.accept()
-            self.emit(Qt.SIGNAL("new_region_chosen"))
+            self.newRegionChosen.emit()
 
 
-class SystemChat(QtGui.QDialog):
+class SystemChat(QtWidgets.QDialog):
     SYSTEM = 0
-
+    
+    setLocationSignal = pyqtSignal(str, str)
+    
     def __init__(self, parent, chatType, selector, chatEntries, knownPlayerNames):
-        QtGui.QDialog.__init__(self, parent)
+        QtWidgets.QDialog.__init__(self, parent)
         uic.loadUi(resourcePath("vi/ui/SystemChat.ui"), self)
         self.parent = parent
         self.chatType = 0
@@ -869,10 +886,10 @@ class SystemChat(QtGui.QDialog):
         for name in knownPlayerNames:
             self.playerNamesBox.addItem(name)
         self.setWindowTitle("Chat for {0}".format(titleName))
-        self.connect(self.closeButton, Qt.SIGNAL("clicked()"), self.closeDialog)
-        self.connect(self.alarmButton, Qt.SIGNAL("clicked()"), self.setSystemAlarm)
-        self.connect(self.clearButton, Qt.SIGNAL("clicked()"), self.setSystemClear)
-        self.connect(self.locationButton, Qt.SIGNAL("clicked()"), self.locationSet)
+        self.closeButton.clicked.connect(self.closeDialog)
+        self.alarmButton.clicked.connect(self.setSystemAlarm)
+        self.clearButton.clicked.connect(self.setSystemClear)
+        self.locationButton.clicked.connect(self.locationSet)
 
 
     def _addMessageToChat(self, message, avatarPixmap):
@@ -886,7 +903,7 @@ class SystemChat(QtGui.QDialog):
         self.chat.addItem(listWidgetItem)
         self.chat.setItemWidget(listWidgetItem, entry)
         self.chatEntries.append(entry)
-        self.connect(entry, Qt.SIGNAL("mark_system"), self.parent.markSystemOnMap)
+        self.markSystem.connect(self.parent.markSystemOnMap)
         if scrollToBottom:
             self.chat.scrollToBottom()
 
@@ -901,7 +918,7 @@ class SystemChat(QtGui.QDialog):
 
     def locationSet(self):
         char = six.text_type(self.playerNamesBox.currentText())
-        self.emit(Qt.SIGNAL("location_set"), char, self.system.name)
+        self.setLocationSignal.emit(char, self.system.name)
 
 
     def newAvatarAvailable(self, charname, avatarData):
@@ -924,20 +941,23 @@ class SystemChat(QtGui.QDialog):
         self.accept()
 
 
-class ChatEntryWidget(QtGui.QWidget):
+class ChatEntryWidget(QtWidgets.QWidget):
+    
+    markSystem = pyqtSignal(object)
+    
     TEXT_SIZE = 11
     SHOW_AVATAR = True
     questionMarkPixmap = None
 
     def __init__(self, message):
-        QtGui.QWidget.__init__(self)
+        QtWidgets.QWidget.__init__(self)
         if not self.questionMarkPixmap:
             self.questionMarkPixmap = QtGui.QPixmap(resourcePath("vi/ui/res/qmark.png"))
         uic.loadUi(resourcePath("vi/ui/ChatEntry.ui"), self)
         self.avatarLabel.setPixmap(self.questionMarkPixmap)
         self.message = message
         self.updateText()
-        self.connect(self.textLabel, QtCore.SIGNAL("linkActivated(QString)"), self.linkClicked)
+        self.textLabel.linkActivated.connect(self.linkClicked)
         if sys.platform.startswith("win32") or sys.platform.startswith("cygwin"):
             ChatEntryWidget.TEXT_SIZE = 8
         self.changeFontSize(self.TEXT_SIZE)
@@ -949,7 +969,7 @@ class ChatEntryWidget(QtGui.QWidget):
         link = six.text_type(link)
         function, parameter = link.split("/", 1)
         if function == "mark_system":
-            self.emit(QtCore.SIGNAL("mark_system"), parameter)
+            self.markSystem.emit(parameter)
         elif function == "link":
             webbrowser.open(parameter)
 
@@ -979,12 +999,14 @@ class ChatEntryWidget(QtGui.QWidget):
         self.textLabel.setFont(font)
 
 
-class JumpbridgeChooser(QtGui.QDialog):
+class JumpbridgeChooser(QtWidgets.QDialog):
+    setJumpBridgeUrl = pyqtSignal(str)
+    
     def __init__(self, parent, url):
-        QtGui.QDialog.__init__(self, parent)
+        QtWidgets.QDialog.__init__(self, parent)
         uic.loadUi(resourcePath("vi/ui/JumpbridgeChooser.ui"), self)
-        self.connect(self.saveButton, Qt.SIGNAL("clicked()"), self.savePath)
-        self.connect(self.cancelButton, Qt.SIGNAL("clicked()"), self.accept)
+        self.saveButton.clicked.connect(self.savePath)
+        self.cancelButton.clicked.connect(self.accept)
         self.urlField.setText(url)
         # loading format explanation from textfile
         with open(resourcePath("docs/jumpbridgeformat.txt")) as f:
@@ -996,7 +1018,7 @@ class JumpbridgeChooser(QtGui.QDialog):
             url = six.text_type(self.urlField.text())
             if url != "":
                 requests.get(url).text
-            self.emit(QtCore.SIGNAL("set_jumpbridge_url"), url)
+            self.setJumpBridgeUrl.emit(url)
             self.accept()
         except Exception as e:
-            QtGui.QMessageBox.critical(None, "Finding Jumpbridgedata failed", "Error: {0}".format(six.text_type(e)), "OK")
+            QtWidgets.QMessageBox.critical(None, "Finding Jumpbridgedata failed", "Error: {0}".format(six.text_type(e)), "OK")

--- a/src/vintel.py
+++ b/src/vintel.py
@@ -26,7 +26,7 @@ import traceback
 from logging.handlers import RotatingFileHandler
 from logging import StreamHandler
 
-from PyQt4 import QtGui
+from PyQt5 import QtGui, QtWidgets
 from vi import version
 from vi.ui import viui, systemtray
 from vi.cache import cache
@@ -53,6 +53,9 @@ backGroundColor = "#c6d9ec"
 
 if __name__ == "__main__":
 
+    # Setup the application object (must be done before using QtWidgets when checking log directory)
+    app = QtWidgets.QApplication(sys.argv)
+
     # Set up paths
     chatLogDirectory = ""
     if len(sys.argv) > 1:
@@ -64,6 +67,9 @@ if __name__ == "__main__":
                                       "p_drive", "User", "My Documents", "EVE", "logs", "Chatlogs")
         elif sys.platform.startswith("linux"):
             chatLogDirectory = os.path.join(os.path.expanduser("~"), "EVE", "logs", "Chatlogs")
+            if not os.path.exists(chatLogDirectory):
+                # Default path created by EveLauncher:  https://forums.eveonline.com/default.aspx?g=posts&t=482663
+                chatLogDirectory = os.path.join(os.path.expanduser("~"), "Documents","EVE", "logs", "Chatlogs")
         elif sys.platform.startswith("win32") or sys.platform.startswith("cygwin"):
             import ctypes.wintypes
             buf = ctypes.create_unicode_buffer(ctypes.wintypes.MAX_PATH)
@@ -72,7 +78,7 @@ if __name__ == "__main__":
             chatLogDirectory = os.path.join(documentsPath, "EVE", "logs", "Chatlogs")
     if not os.path.exists(chatLogDirectory):
         # None of the paths for logs exist, bailing out
-        QtGui.QMessageBox.critical(None, "No path to Logs", "No logs found at: " + chatLogDirectory, "Quit")
+        QtWidgets.QMessageBox.critical(None, "No path to Logs", "No logs found at: " + chatLogDirectory, QtWidgets.QMessageBox.Close)
         sys.exit(1)
 
     # Setting local directory for cache and logging
@@ -85,9 +91,8 @@ if __name__ == "__main__":
     if not os.path.exists(vintelLogDirectory):
         os.mkdir(vintelLogDirectory)
 
-    # Setup the application object, display splash screen
-    app = QtGui.QApplication(sys.argv)
-    splash = QtGui.QSplashScreen(QtGui.QPixmap(resourcePath("vi/ui/res/logo.png")))
+    # Display splash screen
+    splash = QtWidgets.QSplashScreen(QtGui.QPixmap(resourcePath("vi/ui/res/logo.png")))
 
     vintelCache = Cache()
     logLevel = vintelCache.getFromCache("logging_level")


### PR DESCRIPTION
This change moves to the Qt5 imports, and the necessary new-style signalling.

The only other change in here is a check for the logs on Linux in the default EveLauncher chatlog path.  I made that change to simplify launching while I was debugging and forgot to remove it for this patchset.  But, I'm sure a lot of other Linux users use EveLauncher too.

I'm not sure if filewatcher and threads didn't have some non-standard line-endings that got fixed.  Git insists that a lot of lines which are seemingly exactly the same have changed.  None of the other files showed this behavior.