### PR TITLE
Fix Scrollbars

### DIFF
--- a/src/vi/PanningWebView.py
+++ b/src/vi/PanningWebView.py
@@ -29,6 +29,13 @@ class PanningWebView(QWebView if MainWindow.oldStyleWebKit else QWebEngineView):
 
 
     def mousePressEvent(self, mouseEvent):
+        
+        # Ignore if user is using the scrollbars
+        if mouseEvent.buttons() == Qt.LeftButton and \
+        (self.page().mainFrame().scrollBarGeometry(Qt.Horizontal).contains(mouseEvent.pos()) or \
+        self.page().mainFrame().scrollBarGeometry(Qt.Vertical).contains(mouseEvent.pos())):
+            return super(PanningWebView, self).mousePressEvent(mouseEvent)
+            
         if self.ignored.count(mouseEvent):
             self.ignored.remove(mouseEvent)
             return super(PanningWebView, self).mousePressEvent(mouseEvent)


### PR DESCRIPTION
I noticed the scrollbars weren't working (clicking them drags pages), so I made this change to fix that.

I've only tested this with QWebView, you'll have to test with QWebEngineView.

I noticed that (even before this patch), the dragging/scrolling is kind of janky... freezing every few seconds.  We'll need to create an issue for that and correct it separately.