### PR TITLE
Fix parsing of messages with periods

### DIFF
--- a/src/vi/chatparser/parser_functions.py
+++ b/src/vi/chatparser/parser_functions.py
@@ -42,7 +42,7 @@ from bs4.element import NavigableString
 from vi import states
 import vi.evegate as evegate
 
-CHARS_TO_IGNORE = ("*", "?", ",", "!")
+CHARS_TO_IGNORE = ("*", "?", ",", "!", ".")
 
 
 def textReplace(element, newText):


### PR DESCRIPTION
I noticed messages like "N-R clr.. for now" weren't being parsed correctly, so this adds them to the list of characters to ignore.